### PR TITLE
add github action for release checklist

### DIFF
--- a/.github/workflows/release-checklist-comment.yml
+++ b/.github/workflows/release-checklist-comment.yml
@@ -1,0 +1,14 @@
+name: Add release checklist comment
+
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - main
+
+jobs:
+  add-release-template-comment:
+    uses: ASFHyP3/actions/.github/workflows/reusable-release-checklist-comment.yml@v0.7.0
+    secrets:
+      USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}


### PR DESCRIPTION
Triggers are copied from https://github.com/ASFHyP3/hyp3/blob/develop/.github/workflows/release-template-comment.yml

This is the first use of https://github.com/ASFHyP3/actions/blob/develop/.github/workflows/reusable-release-checklist-comment.yml