### PR TITLE
use separate security groups to avoid having to replace image server

### DIFF
--- a/image_server/cloudformation.yml
+++ b/image_server/cloudformation.yml
@@ -63,7 +63,6 @@ Resources:
           SubnetId: !Select [0, !Ref SubnetIds]
           GroupSet:
             - !Ref ImageServerSecurityGroup
-            - !Ref SshSecurityGroup
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:

--- a/image_server/cloudformation.yml
+++ b/image_server/cloudformation.yml
@@ -43,13 +43,6 @@ Resources:
           SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
           ToPort: 6443
           FromPort: 6443
-      VpcId: !Ref VpcId
-
-  SshSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: !Sub "Security group for ${AWS::StackName} servers"
-      SecurityGroupIngress:
         - IpProtocol: tcp
           CidrIp: !Ref SshCidrIp
           ToPort: 22
@@ -81,6 +74,17 @@ Resources:
         - Key: Name
           Value: !Sub "${AWS::StackName}-image-server"
 
+  ProcessingServerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub "Security group for ${AWS::StackName} processing server"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          CidrIp: !Ref SshCidrIp
+          ToPort: 22
+          FromPort: 22
+      VpcId: !Ref VpcId
+
   ProcessingServerInstance:
     Type: AWS::EC2::Instance
     Properties:
@@ -94,7 +98,7 @@ Resources:
           DeleteOnTermination: true
           SubnetId: !Select [0, !Ref SubnetIds]
           GroupSet:
-            - !Ref SshSecurityGroup
+            - !Ref ProcessingServerSecurityGroup
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:


### PR DESCRIPTION
When comparing to what's in `main`, the template now makes no changes to the Image Server and only adds new resources for the processing server, so we won't trigger a replacement of the image server when we deploy to production.

https://github.com/ASFHyP3/gis-services/compare/main...cf-fix