### PR TITLE
switch make_rtc_service.sh from miniconda3 to mambaforge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0]
 ### Changed
 - `make_rtc_service.py` now maintains a CSV table for adding rasters to the mosaic dataset
+- support using mambaforge instead of miniconda3 for python environments
 
 ## [0.2.0]
 ### Added

--- a/image_services/rtc_services/make_rtc_service.sh
+++ b/image_services/rtc_services/make_rtc_service.sh
@@ -5,7 +5,7 @@
 # 0 8 * * * script -qef -c "/home/arcgis/gis-services/image_services/rtc_services/make_rtc_service.sh /home/arcgis/gis-services/image_services/rtc_services/nasa_disasters /home/arcgis/gis-services/image_services/rtc_services/nasa_disasters/rgb.json" -a /home/arcgis/gis-services/image_services/rtc_services/nasa_disasters/make_rgb_service.log
 
 set -e
-source /home/arcgis/miniconda3/etc/profile.d/conda.sh
+source /home/arcgis/mambaforge/etc/profile.d/conda.sh
 conda activate arcpy
 python /home/arcgis/gis-services/image_services/rtc_services/make_rtc_service.py \
   --working-directory $1 \


### PR DESCRIPTION
The new environment file took an intolerable amount of time (more than tens of minutes) to create using `conda`, so I installed `mamba` on gis-test instead. That changes the installation directory path.

I'll make the same change to install mamba on production when these changes are released.

https://mamba.readthedocs.io/en/latest/installation.html