### PR TITLE
Attempt add rasters, publish sd steps up to three times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1]
+### Changed
+- The `AddRastersToMosaicDataset` and `publish_sd` steps of `make_rtc_service.py` are now attempted up to three times
+  to reduce the impact of intermittent errors.
+
 ## [0.3.0]
 ### Changed
 - `make_rtc_service.py` now maintains a CSV table for adding rasters to the mosaic dataset

--- a/image_server/environment.yml
+++ b/image_server/environment.yml
@@ -8,5 +8,6 @@ dependencies:
   - boto3
   - gdal>=2.4.4,<3
   - lxml
+  - tenacity
 variables:
   ARCGISHOME: /opt/arcgis/server/

--- a/image_services/rtc_services/make_rtc_service.py
+++ b/image_services/rtc_services/make_rtc_service.py
@@ -14,7 +14,7 @@ import boto3
 from arcgis.gis.server import Server
 from lxml import etree
 from osgeo import gdal, osr
-from tenacity import Retrying, stop_after_attempt
+from tenacity import Retrying, before_sleep_log, stop_after_attempt
 
 
 def get_rasters(bucket: str, prefix: str, suffix: str) -> List[str]:
@@ -145,9 +145,10 @@ try:
         ],
     )
 
-    logging.info(f'Adding source rasters to {mosaic_dataset}')
-    for attempt in Retrying(stop=stop_after_attempt(3), reraise=True):
+    for attempt in Retrying(stop=stop_after_attempt(3), reraise=True,
+                            before_sleep=before_sleep_log(logging, logging.WARNING)):
         with attempt:
+            logging.info(f'Adding source rasters to {mosaic_dataset}')
             arcpy.management.AddRastersToMosaicDataset(
                 in_mosaic_dataset=mosaic_dataset,
                 raster_type='Table',
@@ -304,9 +305,10 @@ try:
     with open(args.server_connection_file) as f:
         server_connection = json.load(f)
 
-    logging.info(f'Publishing {service_definition}')
-    for attempt in Retrying(stop=stop_after_attempt(3), reraise=True):
+    for attempt in Retrying(stop=stop_after_attempt(3), reraise=True,
+                            before_sleep=before_sleep_log(logging, logging.WARNING)):
         with attempt:
+            logging.info(f'Publishing {service_definition}')
             server = Server(**server_connection)
             server.publish_sd(service_definition, folder=config['service_folder'])
 

--- a/image_services/rtc_services/make_rtc_service.py
+++ b/image_services/rtc_services/make_rtc_service.py
@@ -14,6 +14,7 @@ import boto3
 from arcgis.gis.server import Server
 from lxml import etree
 from osgeo import gdal, osr
+from tenacity import Retrying, stop_after_attempt
 
 
 def get_rasters(bucket: str, prefix: str, suffix: str) -> List[str]:
@@ -145,11 +146,13 @@ try:
     )
 
     logging.info(f'Adding source rasters to {mosaic_dataset}')
-    arcpy.management.AddRastersToMosaicDataset(
-        in_mosaic_dataset=mosaic_dataset,
-        raster_type='Table',
-        input_path=csv_file,
-    )
+    for attempt in Retrying(stop=stop_after_attempt(3), reraise=True):
+        with attempt:
+            arcpy.management.AddRastersToMosaicDataset(
+                in_mosaic_dataset=mosaic_dataset,
+                raster_type='Table',
+                input_path=csv_file,
+            )
 
     logging.info(f'Calculating custom field values in {mosaic_dataset}')
     arcpy.management.CalculateFields(
@@ -300,10 +303,12 @@ try:
 
     with open(args.server_connection_file) as f:
         server_connection = json.load(f)
-    server = Server(**server_connection)
 
     logging.info(f'Publishing {service_definition}')
-    server.publish_sd(service_definition, folder=config['service_folder'])
+    for attempt in Retrying(stop=stop_after_attempt(3), reraise=True):
+        with attempt:
+            server = Server(**server_connection)
+            server.publish_sd(service_definition, folder=config['service_folder'])
 
 except arcpy.ExecuteError:
     logging.error(arcpy.GetMessages())


### PR DESCRIPTION
Uses the [Tenacity](https://tenacity.readthedocs.io/en/latest/) library to attempt the two most error-prone parts of the RTC script up to three times.

In cases where no errors are encountered, the logs will look the same as they do before this change.

A short `WARNING` message will be logged for each failed attempt. If all three attempts fail, the full stack trace for the final attempt will be logged. For example:

```
2023-04-06 23:48:05,008 INFO Creating draft service definition /tmp/tmpnzt1760y.sddraft
2023-04-06 23:48:05,072 INFO Creating service definition /home/arcgis/asjohnston/gis-services/image_services/rtc_services/hkh/HKH_RGB_230406_2344.sd
2023-04-06 23:48:05,176 INFO Publishing /home/arcgis/asjohnston/gis-services/image_services/rtc_services/hkh/HKH_RGB_230406_2344.sd
2023-04-06 23:48:05,212 WARNING Retrying <unknown> in 0.0 seconds as it raised AttributeError: 'Server' object has no attribute 'services'.
2023-04-06 23:48:05,212 INFO Publishing /home/arcgis/asjohnston/gis-services/image_services/rtc_services/hkh/HKH_RGB_230406_2344.sd
2023-04-06 23:48:05,241 WARNING Retrying <unknown> in 0.0 seconds as it raised AttributeError: 'Server' object has no attribute 'services'.
2023-04-06 23:48:05,241 INFO Publishing /home/arcgis/asjohnston/gis-services/image_services/rtc_services/hkh/HKH_RGB_230406_2344.sd
Traceback (most recent call last):
  File "/home/arcgis/mambaforge/envs/asjohnston/lib/python3.7/site-packages/arcgis/gis/server/_common/_base.py", line 87, in __getattr__
    return self._properties.__getitem__(name)
  File "/home/arcgis/mambaforge/envs/asjohnston/lib/python3.7/site-packages/arcgis/_impl/common/_mixins.py", line 346, in __getitem__
    return self._mapping[key]
KeyError: 'services'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "../make_rtc_service.py", line 309, in <module>
    before_sleep=before_sleep_log(logging, logging.WARNING)):
  File "/home/arcgis/mambaforge/envs/asjohnston/lib/python3.7/site-packages/tenacity/__init__.py", line 347, in __iter__
    do = self.iter(retry_state=retry_state)
  File "/home/arcgis/mambaforge/envs/asjohnston/lib/python3.7/site-packages/tenacity/__init__.py", line 325, in iter
    raise retry_exc.reraise()
  File "/home/arcgis/mambaforge/envs/asjohnston/lib/python3.7/site-packages/tenacity/__init__.py", line 158, in reraise
    raise self.last_attempt.result()
  File "/home/arcgis/mambaforge/envs/asjohnston/lib/python3.7/concurrent/futures/_base.py", line 428, in result
    return self.__get_result()
  File "/home/arcgis/mambaforge/envs/asjohnston/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "../make_rtc_service.py", line 313, in <module>
    server.publish_sd(service_definition, folder=config['service_folder'])
  File "/home/arcgis/mambaforge/envs/asjohnston/lib/python3.7/site-packages/arcgis/gis/server/admin/administration.py", line 229, in publish_sd
    if "System" not in self.services.folders:
  File "/home/arcgis/mambaforge/envs/asjohnston/lib/python3.7/site-packages/arcgis/gis/server/_common/_base.py", line 93, in __getattr__
    "'%s' object has no attribute '%s'" % (type(self).__name__, name)
AttributeError: 'Server' object has no attribute 'services'
```