### PR TITLE
Enable pixel cache for image services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6]
+### Changed
+- Enable pixel caching when generating RTC services
+
 ## [0.3.5]
 ### Added
 - Documentation for publishing services to Earthdata GIS using existing MDCS-generated mosaic datasets

--- a/image_services/rtc_services/make_rtc_service.py
+++ b/image_services/rtc_services/make_rtc_service.py
@@ -153,6 +153,7 @@ try:
                 in_mosaic_dataset=mosaic_dataset,
                 raster_type='Table',
                 input_path=csv_file,
+                enable_pixel_cache='USE_PIXEL_CACHE',
             )
 
     logging.info(f'Calculating custom field values in {mosaic_dataset}')

--- a/image_services/rtc_services/make_rtc_service.py
+++ b/image_services/rtc_services/make_rtc_service.py
@@ -259,6 +259,7 @@ try:
         in_mosaic_dataset=mosaic_dataset,
         raster_type='Raster Dataset',
         input_path=s3_overview,
+        enable_pixel_cache='USE_PIXEL_CACHE',
     )
 
     logging.info('Calculating Overview Start and End Dates')


### PR DESCRIPTION
By default, pixel caching is not enabled for services. Esri documentation suggests that pixel caching can be enabled as part of the AddRastersToMosaicDataset function. This PR adds the enable_pixel_spacing parameter to the make_rtc_service code.