### PR TITLE
Set pixel cache path

### DIFF
--- a/image_services/rtc_services/make_rtc_service.py
+++ b/image_services/rtc_services/make_rtc_service.py
@@ -154,6 +154,7 @@ try:
                 raster_type='Table',
                 input_path=csv_file,
                 enable_pixel_cache='USE_PIXEL_CACHE',
+                cache_location='/opt/arcgis/server/usr/directories/arcgiscache'
             )
 
     logging.info(f'Calculating custom field values in {mosaic_dataset}')


### PR DESCRIPTION
When the pixel cache was enabled for the mosaic dataset, we encountered errors at that point in the script. Because the cache path defaults to a Windows-based path, it may be causing problems. This PR defines the cache directory based on the expected path on the Linux server.