### PR TITLE
Remove pixel cache references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.6]
-### Changed
-- Enable pixel caching when generating RTC services
-
 ## [0.3.5]
 ### Added
 - Documentation for publishing services to Earthdata GIS using existing MDCS-generated mosaic datasets

--- a/image_services/rtc_services/make_rtc_service.py
+++ b/image_services/rtc_services/make_rtc_service.py
@@ -153,8 +153,6 @@ try:
                 in_mosaic_dataset=mosaic_dataset,
                 raster_type='Table',
                 input_path=csv_file,
-                enable_pixel_cache='USE_PIXEL_CACHE',
-                cache_location='/opt/arcgis/server/usr/directories/arcgiscache'
             )
 
     logging.info(f'Calculating custom field values in {mosaic_dataset}')
@@ -260,7 +258,6 @@ try:
         in_mosaic_dataset=mosaic_dataset,
         raster_type='Raster Dataset',
         input_path=s3_overview,
-        enable_pixel_cache='USE_PIXEL_CACHE',
     )
 
     logging.info('Calculating Overview Start and End Dates')

--- a/image_services/rtc_services/make_rtc_service.py
+++ b/image_services/rtc_services/make_rtc_service.py
@@ -153,8 +153,6 @@ try:
                 in_mosaic_dataset=mosaic_dataset,
                 raster_type='Table',
                 input_path=csv_file,
-                enable_pixel_cache='USE_PIXEL_CACHE',
-                cache_location='/home/arcgis/gis-services/image_services/pixelcache',
             )
 
     logging.info(f'Calculating custom field values in {mosaic_dataset}')
@@ -260,7 +258,6 @@ try:
         in_mosaic_dataset=mosaic_dataset,
         raster_type='Raster Dataset',
         input_path=s3_overview,
-        enable_pixel_cache='USE_PIXEL_CACHE',
     )
 
     logging.info('Calculating Overview Start and End Dates')


### PR DESCRIPTION
Adding the pixel cache parameters results in unspecified 99999 errors when running the script. This PR reverts the code to the version that did not include the pixel cache parameters. We will continue to troubleshoot, and hope to enable the pixel cache functionality once we figure out what's causing the errors.