### PR TITLE
add read permissions for s3://hyp3-pdc-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.2]
 ### Added
 - Processing script and configuration files to support image services for PDC
-- Permissions for image server to write overviews to `s3://hyp3-pdc-data/`
+- IAM permissions for image server to manage mosaic datasets for `s3://hyp3-pdc-data/`
 
 ## [0.4.1]
 ### Added

--- a/image_server/cloudformation.yml
+++ b/image_server/cloudformation.yml
@@ -155,12 +155,18 @@ Resources:
                 Action:
                 - s3:ListBucket
                 - s3:GetBucketAcl
-                Resource: !Sub "arn:aws:s3:::${Bucket}"
+                Resource:
+                - !Sub "arn:aws:s3:::${Bucket}"
+                - arn:aws:s3:::hyp3-examples
+                - arn:aws:s3:::hyp3-pdc-data
               - Effect: Allow
                 Action:
                 - s3:GetObject
                 - s3:GetObjectVersion
-                Resource: !Sub "arn:aws:s3:::${Bucket}/*"
+                Resource:
+                - !Sub "arn:aws:s3:::${Bucket}/*"
+                - arn:aws:s3:::hyp3-examples/*
+                - arn:aws:s3:::hyp3-pdc-data/*
               - Effect: Allow
                 Action: s3:PutObject
                 Resource:


### PR DESCRIPTION
I included `hyp3-examples` for completeness, even though it's not strictly necessary here.

When the server and bucket are in the same account, either side of the handshake can allow access. Since hyp3-examples already grants public read, we didn't have to explicitly grant read permissions for the server.

When the server and bucket are in different accounts, both sides of the handshake need to explicitly grant access. The hyp3-pdc-data already grants public read, but we also need to grant the server read permissions.