### PR TITLE
Refactor the addRasters retry loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.3]
 ### Changed
 - Refactored the addRasters retry loop in the make_pdc_service.py script to avoid duplicate entries in the mosaic dataset attribute table
-- 
+
 ## [0.4.2]
 ### Added
 - Processing script and configuration files to support image services for PDC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.3]
+### Changed
+- Refactored the addRasters retry loop in the make_pdc_service.py script to avoid duplicate entries in the mosaic dataset attribute table
+- 
 ## [0.4.2]
 ### Added
 - Processing script and configuration files to support image services for PDC


### PR DESCRIPTION
This PR refactors the retry loop for the addRasters function so that it starts the retry from the create gdb function. This eliminates the issue where a retry would double the entries in the mosaic dataset table. The today variables and all variables dependent on it have also been moved into the retry block so that a new gdb is generated for each retry attempt, avoiding the error encountered when generating a gdb with the same name as the original.