### PR TITLE
Release 0.6.5 - Time slider length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.6.5]
+### Changed
+- Changed time slider length to 52 weeks for automated web maps
+
 ## [0.6.4]
 ### Added
 - A new hotfix stored in our S3 bucket in `image_server/arcgis_setup.sh`

--- a/image_services/updating_scripts/time_slider_updates.py
+++ b/image_services/updating_scripts/time_slider_updates.py
@@ -16,7 +16,7 @@ def datetime_to_esri(date_time):
 
 def update_time_slider(item):
     data = item.get_data()
-    slider_length = datetime.timedelta(weeks=51)
+    slider_length = datetime.timedelta(weeks=52)
     window_length = datetime.timedelta(weeks=3)
     buffer_length = datetime.timedelta(days=1)
 


### PR DESCRIPTION
This release changes the length of the time sliders in automatically updated web maps to a full year (52 weeks rather than 51).