### PR TITLE
Clean up CF file 

### DIFF
--- a/image_server/cloudformation.yml
+++ b/image_server/cloudformation.yml
@@ -17,9 +17,6 @@ Parameters:
   SshCidrIp:
     Type: String
 
-  Bucket:
-    Type: String
-
   ImageId:
     Type: AWS::EC2::Image::Id
     Default: ami-0b1ddcef10ffe54fb
@@ -27,10 +24,6 @@ Parameters:
   InstanceType:
     Type: String
     Default: m6i.2xlarge
-
-  OverviewPrefix:
-    Type: String
-    Default: overviews/
 
   SecretArn:
     Type: String
@@ -171,11 +164,11 @@ Resources:
               - Effect: Allow
                 Action: s3:PutObject
                 Resource:
-                - !Sub "arn:aws:s3:::${Bucket}/${OverviewPrefix}*"
-                - !Sub "arn:aws:s3:::hyp3-examples/${OverviewPrefix}*"
-                - !Sub "arn:aws:s3:::hyp3-pdc-data/${OverviewPrefix}*"
-                - arn:aws:s3:::hyp3-testing/*/
-                - arn:aws:s3:::gis-services-overviews/*/
+                  - arn:aws:s3:::hyp3-nasa-disasters/*
+                  - arn:aws:s3:::hyp3-examples/*
+                  - arn:aws:s3:::hyp3-pdc-data/*
+                  - arn:aws:s3:::hyp3-testing/*
+                  - arn:aws:s3:::gis-services-overviews/*
               - Effect: Allow
                 Action: secretsmanager:GetSecretValue
                 Resource: !Ref SecretArn

--- a/image_server/cloudformation.yml
+++ b/image_server/cloudformation.yml
@@ -17,6 +17,9 @@ Parameters:
   SshCidrIp:
     Type: String
 
+  Bucket:
+    Type: String
+
   ImageId:
     Type: AWS::EC2::Image::Id
     Default: ami-0b1ddcef10ffe54fb
@@ -24,6 +27,10 @@ Parameters:
   InstanceType:
     Type: String
     Default: m6i.2xlarge
+
+  OverviewPrefix:
+    Type: String
+    Default: overviews/
 
   SecretArn:
     Type: String
@@ -164,7 +171,11 @@ Resources:
               - Effect: Allow
                 Action: s3:PutObject
                 Resource:
-                - arn:aws:s3:::*/overviews/*
+                - !Sub "arn:aws:s3:::${Bucket}/${OverviewPrefix}*"
+                - !Sub "arn:aws:s3:::hyp3-examples/${OverviewPrefix}*"
+                - !Sub "arn:aws:s3:::hyp3-pdc-data/${OverviewPrefix}*"
+                - arn:aws:s3:::hyp3-testing/*/
+                - arn:aws:s3:::gis-services-overviews/*/
               - Effect: Allow
                 Action: secretsmanager:GetSecretValue
                 Resource: !Ref SecretArn

--- a/image_server/cloudformation.yml
+++ b/image_server/cloudformation.yml
@@ -164,11 +164,11 @@ Resources:
               - Effect: Allow
                 Action: s3:PutObject
                 Resource:
-                  - arn:aws:s3:::hyp3-nasa-disasters/*
-                  - arn:aws:s3:::hyp3-examples/*
-                  - arn:aws:s3:::hyp3-pdc-data/*
+                  - arn:aws:s3:::hyp3-nasa-disasters/overviews/*
+                  - arn:aws:s3:::hyp3-examples/overviews/*
+                  - arn:aws:s3:::hyp3-pdc-data/overviews/*
                   - arn:aws:s3:::hyp3-testing/*
-                  - arn:aws:s3:::gis-services-overviews/*
+                  - arn:aws:s3:::gis-service-overviews/*
               - Effect: Allow
                 Action: secretsmanager:GetSecretValue
                 Resource: !Ref SecretArn


### PR DESCRIPTION
This PR addresses Issue #153 to restrict the number of s3 buckets the server has full access to. The buckets we need to ensure we can upload to are:

- `hyp3-examples/overviews`
- `hyp3-pdc-data/overviews`
- `gis-services-overviews/*/`

I wasn't quite sure about some other things, so if @asjohnston-asf or @hjkristenson have thoughts on these questions, please let me know.  

- Do we need to specifically include `hyp3-testing` here, too? 
- Should we hard-code the `hyp3-nasa-disasters/overviews` bucket, or is it safe to assume that the CloudFormation stack will have its $Bucket as `hyp3-nasa-disasters` and its $OverviewPrefix as `overviews`? 
- Do the `GetObject` and `GetBucket` resources need further restricting, too, or is it ok to restrict just the `PutObject` resources. 