### PR TITLE
Change overview bucket back to hyp3-nasa-disasters

### DIFF
--- a/image_server/cloudformation.yml
+++ b/image_server/cloudformation.yml
@@ -164,6 +164,7 @@ Resources:
               - Effect: Allow
                 Action: s3:PutObject
                 Resource:
+                  - arn:aws:s3:::hyp3-nasa-disasters/overviews/*
                   - arn:aws:s3:::asf-event-data/image-services/overviews/*
                   - arn:aws:s3:::hyp3-examples/overviews/*
                   - arn:aws:s3:::hyp3-testing/*

--- a/image_services/rtc_services/make_rtc_service.py
+++ b/image_services/rtc_services/make_rtc_service.py
@@ -146,7 +146,7 @@ args = parser.parse_args()
 
 raster_store = '/home/arcgis/raster_store/'
 bucket = 'asf-event-data'
-overview_path = '/vsis3/asf-event-data/image-services/overviews/'
+overview_path = '/vsis3/hyp3-nasa-disasters/overviews/'
 template_directory = Path(__file__).parent.absolute() / 'raster_function_templates'
 
 with open(args.config_file) as f:


### PR DESCRIPTION
There are permissions issues with accessing overview crf files in s3://asf-event-data/image-services/overviews. Until this issue has been resolved, we can continue to use s3://hyp3-nasa-disasters/overviews to host overviews for RTC services. 